### PR TITLE
Provide script for building the conda environment

### DIFF
--- a/DAWN/examples/multi_node_accelerate/README.md
+++ b/DAWN/examples/multi_node_accelerate/README.md
@@ -2,17 +2,24 @@
 
 ## Setup
 
-1. Install miniconda using [these](https://docs.anaconda.com/free/miniconda/miniconda-install/#installing-miniconda) instructions.
-1. To create an environment, you'll need to either:
-   1. Initialise it for the whole of your shell with `conda init`.
-   2. Enable it for this shell session with `source ~/miniconda3/etc/profile.d/conda.sh`.
-1. Create a Python 3.10 environment with the packages specified in `environment.yaml`. **Note** Using these versions is important as (at least some) versions of Torch 2.1 are known not to work.
+Batch execute the script to create the conda environment on a compute note.
+This will install conda, create the environment and install the requirements in
+the environment.
+```
+sbatch sbatch_initconda.sh
+```
+
+This will create a Python 3.10 environment with the packages specified in
+`environment.yaml`. Using these versions is important as (at least some)
+versions of Torch 2.1 are known not to work.
 
 ## Run
 
-1. Re-initialise conda, if you are in a new SSH session.
-1. Activate the conda environemnt with `conda activate path/name`.
-1. Submit the job with `sbatch sbatch_example.sh`.
-1. Check the job's status with `sacct`.
-1. View the job's output with `cat job.out`.
-   
+Batch execute the script to run the two-node, eight-GPU PyTorch training
+script.
+```
+sbatch sbatch_example.sh
+```
+
+Follow the job's output with `tail -f job.out`. Follow the GPU usage with `tail
+-f dmon-*.txt` and the CPU usage with `tail -f cmon-*.txt`. 

--- a/DAWN/examples/multi_node_accelerate/sbatch_example.sh
+++ b/DAWN/examples/multi_node_accelerate/sbatch_example.sh
@@ -10,10 +10,14 @@
 set -o errexit
 
 # Set up the environment.
+module load intelpython-conda/2024.0.1.3
 module load intel-oneapi-tbb/2021.11.0/oneapi/xtkj6nyp
 module load intel-oneapi-compilers/2024.0.0/gcc/znjudqsi
 module load intel-oneapi-mkl/2024.0.0/oneapi/4n7ruz44
 module load intel-oneapi-mpi/2021.11.0/oneapi/h7nq7sah
+
+# Activate conda environment
+conda activate torch-env
 
 # Avoid too many open file handles error.
 ulimit -n 1000000
@@ -31,9 +35,17 @@ export CCL_ZE_IPC_EXCHANGE=sockets
 # So that accelerate loads the ccl backend.
 export CCL_WORKER_COUNT=1
 
+# Capture usage
+xpu-smi discovery --dump 1,2,16,19
+stdbuf -o0 vmstat -t 1 -y > "cpu-${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}".txt &
+stdbuf -o0 xpu-smi dump -m 0,1,2 -i 1 > "dmon-${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}".txt &
+
 # Check that we can call mpirun with something simple.
 mpirun -n 16 -ppn 8 -prepend-rank hostname
 
 # Do training.
 /usr/bin/time mpirun -n 16 -ppn 8 -prepend-rank accelerate launch --config_file xpu-multinode.yaml example.py
+
+# Deactivate conda environment
+conda deactivate
 

--- a/DAWN/examples/multi_node_accelerate/sbatch_initconda.sh
+++ b/DAWN/examples/multi_node_accelerate/sbatch_initconda.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --partition=pvc
+#SBATCH --time=00:20:00
+#SBATCH --nodes=1
+#SBATCH --gpus=1
+#SBATCH --output=initconda.out
+#SBATCH --cpus-per-gpu=1
+
+set -o errexit
+
+# Set up the environment.
+module load intelpython-conda/2024.0.1.3
+
+# Configure conda shell
+conda init
+
+# Install packages
+conda env create -f environment.yaml
+
+# Activate conda environment
+conda activate torch-env
+
+# Check python version (should be 3.10)
+python --version
+
+# Deactivate conda environment
+conda deactivate
+
+# To remove the environment
+#conda remove --name torch-env --all -y
+


### PR DESCRIPTION
Provides a script that can be used to create the conda environment using a compute node.

I'm not expecting this to get merged in, it's more for comparison. I wasn't sure how the conda environment could be initiallised from outside the batch file, so made the amendments here. I'd be interested to know what I should have done.