### PR TITLE
Add Llama 2 and Llama 3 inference walkthroughs

### DIFF
--- a/Baskerville/llama-download.md
+++ b/Baskerville/llama-download.md
@@ -4,7 +4,7 @@ We’ll be downloading the models from:
 
 https://llama.meta.com/llama-downloads
 
-This involves agreeing to the T&Cs in order to get keys, then following the instructions in the [REAMDE](https://github.com/meta-llama/llama3).
+This involves agreeing to the T&Cs in order to get keys, then following the instructions in the [README](https://github.com/meta-llama/llama3).
 
 We can do all of this on a Baskerville login node, so make sure you’ve SSH-ed into Baskerville before continuing.
 
@@ -119,7 +119,7 @@ $ du -hs CodeLlama-*
 
 Having downloaded the models you’ll want to make use of them.
 Take a look at one of the following files to see how to execute them for inference on Baskerville:
-1. `llama3-inference-srun.md`: execute from the command line using `srun`.
-2. `llama3-inference-sbatch.md` execute using a batch script.
+1. `llama3-inference-srun.md`: instructions for executing Llama3 on the command line using `srun`.
+2. `llama3-inference-sbatch.md`: instructions for executing Llama3 using a batch script and `sbatch`.
 
 

--- a/Baskerville/llama-download.md
+++ b/Baskerville/llama-download.md
@@ -1,0 +1,125 @@
+# Llama download on Baskerville
+
+We’ll be downloading the models from:
+
+https://llama.meta.com/llama-downloads
+
+This involves agreeing to the T&Cs in order to get keys, then following the instructions in the [REAMDE](https://github.com/meta-llama/llama3).
+
+We can do all of this on a Baskerville login node, so make sure you’ve SSH-ed into Baskerville before continuing.
+
+## 1. Clone the repositories:
+
+```shell
+$ git clone https://github.com/meta-llama/llama3.git
+$ git clone https://github.com/meta-llama/llama
+$ git clone https://github.com/meta-llama/codellama.git
+```
+
+## 2. Download Meta Llama 3
+
+Run the download script and supply the relevant URL.
+The prerequisites (`wget` and `md5sum`) are already installed on Baskerville.
+
+```shell
+$ cd llama3
+$ ./download.sh
+Enter the URL from email: https://download6.llamameta.net/*?...
+
+Enter the list of models to download without spaces (8B,8B-instruct,70B,70B-instruct), or press Enter for all: <ENTER>
+```
+
+The total time taken to download all of the models:
+
+```shell
+real    36m55.852s
+user    12m29.470s
+sys     13m3.270s
+```
+
+The size of the files on disk:
+
+```shell
+$ du -hs Meta-Llama-3-*
+132G    Meta-Llama-3-70B
+132G    Meta-Llama-3-70B-Instruct
+15G     Meta-Llama-3-8B
+15G     Meta-Llama-3-8B-Instruct
+```
+
+## 3. Download Meta Llama
+
+Run the download script and supply the relevant URL:
+
+```shell
+$ cd llama
+$ ./download.sh
+Enter the URL from email: https://download6.llamameta.net/*?...
+
+Enter the list of models to download without spaces (8B,8B-instruct,70B,70B-instruct), or press Enter for all: <ENTER>
+```
+
+The total time taken to download all of the models:
+
+```shell
+real    42m49.237s
+user    14m12.291s
+sys     14m53.573s
+```
+
+The size of the files on disk:
+
+```shell
+$ du -hs llama-2-*
+25G     llama-2-13b
+25G     llama-2-13b-chat
+129G    llama-2-70b
+129G    llama-2-70b-chat
+13G     llama-2-7b
+13G     llama-2-7b-chat
+```
+
+## 4. Download Meta Code Llama
+
+```shell
+$ cd codellama
+$ ./download.sh
+Enter the URL from email: https://download6.llamameta.net/*?...
+
+Enter the list of models to download without spaces (8B,8B-instruct,70B,70B-instruct), or press Enter for all: <ENTER>
+```
+
+The total time taken to download all of the models:
+
+```shell
+real    324m52.569s
+user    29m56.629s
+sys     35m47.038s
+```
+
+The size of the files on disk:
+
+```shell
+$ du -hs CodeLlama-*
+25G     CodeLlama-13b
+25G     CodeLlama-13b-Instruct
+25G     CodeLlama-13b-Python
+63G     CodeLlama-34b
+63G     CodeLlama-34b-Instruct
+63G     CodeLlama-34b-Python
+129G    CodeLlama-70b
+48G     CodeLlama-70b-Instruct
+129G    CodeLlama-70b-Python
+13G     CodeLlama-7b
+13G     CodeLlama-7b-Instruct
+13G     CodeLlama-7b-Python
+```
+
+## 5. Make use of the models.
+
+Having downloaded the models you’ll want to make use of them.
+Take a look at one of the following files to see how to execute them for inference on Baskerville:
+1. `llama3-inference-srun.md`: execute from the command line using `srun`.
+2. `llama3-inference-sbatch.md` execute using a batch script.
+
+

--- a/Baskerville/llama2-inference-sbatch.md
+++ b/Baskerville/llama2-inference-sbatch.md
@@ -30,6 +30,8 @@ Using your favourite text editor, create a batch file with the contents below.
 
 In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA2_PATH>` with the full path of your cloned llama repository from Step 1.
 
+If it doesn't already exist, a virtual environment will be created and configured automatically in a directory called `venv` immediately inside the directory you set `<LLAMA2_PATH>` to.
+
 Make sure you call the script `batch-llama2-7b-inf.sh`.
 Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
 
@@ -152,7 +154,7 @@ River Seine's gentle flow
 
 ## Llama 2 13B inference, single node, two GPUs
 
-The 13B parameter Llama 2 model will run with tow processes on a single node with two GPUs.
+The 13B parameter Llama 2 model will run with two processes on a single node with two GPUs.
 The checkpoint provided requires this configuration.
 
 We found at least 32 GiB of RAM was needed to run the model.

--- a/Baskerville/llama2-inference-sbatch.md
+++ b/Baskerville/llama2-inference-sbatch.md
@@ -1,0 +1,433 @@
+# Llama 2 inference on Baskerville using `sbatch`
+
+Before you can make use of them you’ll need to download the models.
+See [llama-download.md](llama-download.md) for how to go about doing this on Baskerville.
+
+## Llama 2 7B inference, single node, single GPU
+
+The 7B parameter Llama 2 model will run with a single process on a single node with a single GPU.
+The checkpoint provided for use with the example will, in fact, only work with a single process.
+
+We found at least 16 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured through `sbatch` header for things to work.
+
+## 1. Get the full path of your llama directory.
+
+You should already have the llama git repository cloned to Baskerville.
+You’ll need the full path of where you cloned it to for the script.
+You can find this by moving into the directory and then running the `pwd` (print working directory) command:
+
+```shell
+$ cd llama
+$ pwd
+```
+
+## 2. Create the batch script.
+
+Using your favourite text editor, create a batch file with the contents below.
+
+In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA2_PATH>` with the full path of your cloned llama repository from Step 1.
+
+Make sure you call the script `batch-llama2-7b-inf.sh`.
+Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
+
+```shell
+#!/bin/bash
+#SBATCH --qos turing
+#SBATCH --account <PROJECT_ID>
+#SBATCH --time 0:30:0
+#SBATCH --nodes 1
+#SBATCH --gpus 1
+#SBATCH --mem 16384
+#SBATCH --job-name llama2-7b-inf
+
+# Execute using:
+# sbatch -o stdout-%A_%a.out ./batch-llama2-7b-inf.sh
+
+module purge
+module load baskerville
+module load bask-apps/live
+module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+
+VENV_PATH="./venv"
+
+pushd <LLAMA2_PATH>
+
+if [ -d "$VENV_PATH" ]; then
+    echo "Virtual environment exists, activating"
+    . "${VENV_PATH}"/bin/activate
+else
+    echo "Creating and activating virtual environment"
+    python3 -m venv "${VENV_PATH}"
+    . "${VENV_PATH}"/bin/activate
+    echo "Installing requirements"
+    pip install pip --upgrade
+    pip install -e .
+    pip install -r requirements.txt
+fi
+
+export OMP_NUM_THREADS=1
+
+echo
+echo "######################################"
+echo "Starting"
+echo "######################################"
+echo
+
+python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 1 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-7b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+
+echo
+echo "######################################"
+echo "Done"
+echo "######################################"
+echo
+
+echo "Deactivating virtual environment"
+deactivate
+popd
+```
+
+You’ll either need to create this batch file directly on Baskerville, or transfer it to Baskerville.
+It doesn’t matter where you store it on Baskerville.
+
+## 3. Schedule the job file to run.
+
+```shell
+$ sbatch -o stdout-%A_%a.out ./batch-llama2-7b-inf.sh
+```
+
+## 4. Check the status of your job.
+
+Use the following command to check the status of your job.
+Once it’s completed it will disappear from the queue.
+
+```shell
+$ squeue --me
+```
+
+This is a small job so it shouldn’t take too long to schedule and run (it took less than five minutes for me, but will depend on how busy Baskerville is when you run it).
+
+## 5. View the results in realtime.
+
+The console output from the job will be stored in a file with a name of the form `stdout-%A_%a.out` where the `%A` and `%a` are replaced by the job ID and array index respectively.
+For example, for me the file was called `stdout-763144_4294967294.out`.
+
+If you want to follow the progress of the execution in real time &mdash; while it’s running that is &mdash; you can execute the following command to follow the output.
+If you have multiple output files you may need to specify the filename explicitly, rather than relying on the `*` wildcard.
+
+```shell
+tail -f stdout-*.out
+```
+
+## 6. View the results after completion.
+
+Once the job has completed you can view open the `stdout-%A_%a.out` file to see the results.
+It should contain something like this:
+
+```text
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+Love locks on bridge embrace
+River Seine's gentle flow
+
+==================================
+[...]
+```
+
+## Llama 2 13B inference, single node, two GPUs
+
+The 13B parameter Llama 2 model will run with tow processes on a single node with two GPUs.
+The checkpoint provided requires this configuration.
+
+We found at least 32 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured through `sbatch` header for things to work.
+
+## 7. Create the batch script.
+
+Using your favourite text editor, create a batch file with the contents below.
+
+In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA2_PATH>` with the full path of your cloned llama repository from Step 1.
+
+Make sure you call the script `batch-llama2-13b-inf.sh`.
+Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
+
+```shell
+#!/bin/bash
+#SBATCH --qos turing
+#SBATCH --account <PROJECT_ID>
+#SBATCH --time 0:30:0
+#SBATCH --nodes 1
+#SBATCH --gpus 2
+#SBATCH --mem 32768
+#SBATCH --job-name llama2-13b-inf
+
+# Execute using:
+# sbatch -o stdout-%A_%a.out ./batch-llama2-13b-inf.sh
+
+module purge
+module load baskerville
+module load bask-apps/live
+module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+
+VENV_PATH="./venv"
+
+pushd <LLAMA2_PATH>
+
+if [ -d "$VENV_PATH" ]; then
+    echo "Virtual environment exists, activating"
+    . "${VENV_PATH}"/bin/activate
+else
+    echo "Creating and activating virtual environment"
+    python3 -m venv "${VENV_PATH}"
+    . "${VENV_PATH}"/bin/activate
+    echo "Installing requirements"
+    pip install pip --upgrade
+    pip install -e .
+    pip install -r requirements.txt
+fi
+
+export OMP_NUM_THREADS=1
+
+echo
+echo "######################################"
+echo "Starting"
+echo "######################################"
+echo
+
+python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 2 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-13b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+
+echo
+echo "######################################"
+echo "Done"
+echo "######################################"
+echo
+
+echo "Deactivating virtual environment"
+deactivate
+popd
+```
+
+You’ll either need to create this batch file directly on Baskerville, or transfer it to Baskerville.
+It doesn’t matter where you store it on Baskerville.
+
+## 8. Schedule the job file to run.
+
+```shell
+$ sbatch -o stdout-%A_%a.out ./batch-llama2-13b-inf.sh
+```
+
+## 9. Check the status of your job.
+
+Use the following command to check the status of your job.
+Once it’s completed it will disappear from the queue.
+
+```shell
+$ squeue --me
+```
+
+This is a small job so it shouldn’t take too long to schedule and run (it took less than five minutes for me, but will depend on how busy Baskerville is when you run it).
+
+## 10. View the results in realtime.
+
+The console output from the job will be stored in a file with a name of the form `stdout-%A_%a.out` where the `%A` and `%a` are replaced by the job ID and array index respectively.
+For example, for me the file was called `stdout-763144_4294967294.out`.
+
+If you want to follow the progress of the execution in real time &mdash; while it’s running that is &mdash; you can execute the following command to follow the output.
+If you have multiple output files you may need to specify the filename explicitly, rather than relying on the `*` wildcard.
+
+```shell
+tail -f stdout-*.out
+```
+
+## 11. View the results after completion.
+
+Once the job has completed you can view open the `stdout-%A_%a.out` file to see the results.
+It should contain something like this:
+
+```text
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+River Seine's gentle flow
+Art and love in air
+
+==================================
+[...]
+```
+
+## Llama 2 70B inference, two nodes, eight GPUs
+
+The 70B parameter LLama 2 model requires considerably more resources to execute compared to the 8B parameter model.
+The checkpoint provided for the example script requires eight processes and eight GPUs.
+On Baskerville this means we’ll need to use two nodes, each with four GPUs.
+
+Thankfully it’s considerably easier to do this using `sbatch` compared to `srun`.
+Let’s do it now.
+
+## 12. Create the batch script.
+
+Using your favourite text editor, create a batch file with the contents below.
+
+In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA2_PATH>` with the full path of your cloned llama repository from Step 1.
+
+Make sure you call the script `batch-llama2-70b-inf.sh`.
+Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
+
+```shell
+#!/bin/bash
+#SBATCH --qos turing
+#SBATCH --account <PROJECT_ID>
+#SBATCH --time 0:30:0
+#SBATCH --nodes 2
+#SBATCH --gpus-per-node 4
+#SBATCH --ntasks-per-node 1
+#SBATCH --mem 131072
+#SBATCH --job-name llama2-70b-inf
+
+# Execute using:
+# sbatch -o stdout-%A_%a.out ./batch-llama2-70b-inf.sh
+
+module purge
+module load baskerville
+module load bask-apps/live
+module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+
+VENV_PATH="./venv"
+
+pushd <LLAMA2_PATH>
+
+if [ -d "$VENV_PATH" ]; then
+  echo "Virtual environment exists, activating"
+  . "${VENV_PATH}"/bin/activate
+else
+  echo "Creating and activating virtual environment"
+  python3 -m venv "${VENV_PATH}"
+  . "${VENV_PATH}"/bin/activate
+  echo "Installing requirements"
+  pip install pip --upgrade
+  pip install -e .
+  pip install -r requirements.txt
+fi
+
+export PRIMARY_PORT=12340
+export PRIMARY_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export OMP_NUM_THREADS=1
+
+echo
+echo "######################################"
+echo "Starting"
+echo "######################################"
+echo
+
+srun bash -c \
+    'python -m torch.distributed.run \
+    --nnodes ${SLURM_NNODES} \
+    --nproc_per_node ${SLURM_GPUS_PER_NODE} \
+    --master_addr ${PRIMARY_ADDR} \
+    --master_port ${PRIMARY_PORT} \
+    --node_rank ${SLURM_NODEID} \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-70b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6'
+
+echo
+echo "######################################"
+echo "Done"
+echo "######################################"
+echo
+
+echo "Deactivating virtual environment"
+deactivate
+popd
+```
+
+Once again, you’ll need to either create this script directly on Baskerville or copy it over.
+
+There are a couple of important things to note about this script.
+First, because we’re running across multiple nodes using `torchrun` we have to pass our training command through `srun`.
+This will ensure multiple processes get spawned, one on each node.
+The syntax for `srun` is to execute the command passed as a parameter on each of the nodes.
+
+We also need to pass various parameters to our Python script, some of which are taken from environment variables.
+The second point to note is about these parameters.
+Most of the parameters can be set to the same value for each process, but there’s one exception, which is the value passed as the node rank: `--node_rank ${SLURM_NODEID}`.
+This needs to take a different value on each node so that the nodes can communicate with each other successfully.
+
+The `SLURM_NODEID` environment variable will automatically be set to a different value on each node by `srun`.
+However this means we need to be careful about how we pass the command to `srun`.
+If we passed the `python` command directly, this `SLURM_NODEID` will be resolved on the spawning node and its value will then end up the same on each node.
+
+Consequently we have to create a string out of our entire command and use `bash` to run the command.
+That way `srun` will spawn the `bash` shell on each node, which will then interpret the `python` command on that node.
+The `SLURM_NODEID` environment variable won’t then get resolved until the command is run on the node, which is what we need.
+
+## 13. Schedule the job file to run.
+
+```shell
+$ sbatch -o stdout-%A_%a.out ./batch-llama2-70b-inf.sh
+```
+
+## 14. Follow the results.
+
+As before you can check the status of your job using the following:
+
+```shell
+squeue --me
+```
+
+You can also check the output of the `stdout-%A_%a.out` file to see the results, either by following it during execution or opening the file afterwards.
+
+## 15. View the results after completion.
+
+Once the job has completed you can view open the `stdout-%A_%a.out` file to see the results.
+It should contain something like this:
+
+```text
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+Art museums and fashion streets
+Romance in the air
+
+==================================
+[...]
+```
+

--- a/Baskerville/llama2-inference-srun.md
+++ b/Baskerville/llama2-inference-srun.md
@@ -3,7 +3,7 @@
 Before you can make use of them you’ll need to download the models.
 See [llama-download.md](llama-download.md) for how to go about doing this on Baskerville.
 
-# Llama 2 7B inference, single node, single GPU
+## Llama 2 7B inference, single node, single GPU
 
 The 7B parameter Llama 2 model will run with a single process on a single node with a single GPU.
 The checkpoint provided for use with the example will, in fact, only work with a single process.
@@ -13,7 +13,7 @@ With too little RAM the process will be sent a SIGKILL termination signal, the p
 
 The RAM, node, GPU and process quantities must be explicitly configured using `srun` for things to work.
 
-## 1. Log in to a single node with a single GPU and a suitable configuration:
+### 1. Log in to a single node with a single GPU and a suitable configuration:
 
 You’ll need to replace `<PROJECT_ID>` with the name of your project.
 
@@ -27,7 +27,7 @@ $ srun --qos turing \
     --pty bash
 ```
 
-## 2. Set up the environment on the node:
+### 2. Set up the environment on the node:
 
 Note that the very first command here moves in to the `llama` directory, which is the directory containing the `example_text_completion.py` file.
 We have to be inside this directory for things to work.
@@ -45,7 +45,7 @@ $ pip install -e .
 $ pip install -r requirements.txt
 ```
 
-## 3. Run the example script that performs a bunch of inference steps:
+### 3. Run the example script that performs a bunch of inference steps:
 
 ```shell
 $ python -m torch.distributed.run \
@@ -83,7 +83,7 @@ One things to note is that in the Llama docs it [recommends](https://github.com/
 When `torchrun` is used directly in this way it doesn’t support Python virtual environments because it defaults to the system-installed Python.
 To circumvent this we’ve switched `torchrun` out for `python -m torch.distributed.run` instead.
 
-## 4. Tidy up
+### 4. Tidy up
 
 Once you’re done don’t forget to log out of the node so that it can be released for access by someone else.
 If you forget to do this the node will automatically close your session once the full 30 minutes you requested are up.
@@ -93,7 +93,7 @@ $ deactivate
 $ exit
 ```
 
-# Llama 2 13B inference, single node, two GPUs
+## Llama 2 13B inference, single node, two GPUs
 
 The 13B parameter Llama 2 model will run with two processes on a single node with two GPUs.
 This arrangement is a requirement for the checkpoint to work.
@@ -103,7 +103,7 @@ With too little RAM the process will be sent a SIGKILL termination signal, the p
 
 The RAM, node, GPU and process quantities must be explicitly configured using `srun` for things to work.
 
-## 5. Log in to a single node with a single GPU and a suitable configuration:
+### 5. Log in to a single node with a single GPU and a suitable configuration:
 
 You’ll need to replace `<PROJECT_ID>` with the name of your project.
 
@@ -117,7 +117,7 @@ $ srun --qos turing \
     --pty bash
 ```
 
-## 6. Set up the environment on the node:
+### 6. Set up the environment on the node:
 
 We assume you’re already in the `llama` directory as in step 2 above.
 If not you should use `cd` to move there first.
@@ -133,7 +133,7 @@ $ . ./venv/bin/activate
 We’re also assuming here that the virtual environment was already created in step 2 above, so we just activate it.
 If you’ve not already done this then you’ll need to run the commands there to create it as well.
 
-## 7. Run the example script that performs a bunch of inference steps:
+### 7. Run the example script that performs a bunch of inference steps:
 
 ```shell
 $ python -m torch.distributed.run \
@@ -167,7 +167,7 @@ Art and love in air
 [...]
 ```
 
-## 8. Tidy up
+### 8. Tidy up
 
 Once you’re done don’t forget to log out of the node so that it can be released for access by someone else.
 If you forget to do this the node will automatically close your session once the full 30 minutes you requested are up.
@@ -177,7 +177,7 @@ $ deactivate
 $ exit
 ```
 
-# Llama 2 70B inference, two nodes, eight GPUs
+## Llama 2 70B inference, two nodes, eight GPUs
 
 The 70B parameter LLama 2 model requires considerably more resources to execute compared to the smaller Llama 2 models.
 The checkpoint provided for the example script requires eight processes and eight GPUs.
@@ -189,7 +189,7 @@ Using `screen` or `tmux` will make your life a lot easier when doing this.
 If you’re not comfortable with either of these, as an alternative you can open two terminals and log in to Baskerville twice.
 You’ll end up with a similar experience.
 
-## 9. Provision two nodes:
+### 9. Provision two nodes:
 
 Here you’ll again need to replace `<PROJECT_ID>` with the name of your project.
 
@@ -207,7 +207,7 @@ In the above command we’re provisioning two nodes, eight GPUs and 32 GiB of RA
 We’ll need all of this computing power to run the model (the checkpoint requires eight processes).
 The `srun` command above not only provisions the node, it also logs you in to one of them.
 
-## 10. Find the names of the nodes.
+### 10. Find the names of the nodes.
 
 ```shell
 $ squeue --me --format="%N" --noheader
@@ -227,7 +227,7 @@ bask-pg0308u05a,bask-pg0308u06a
 
 So I’d replace any instance of `<PRIMARY_NODE>` in the commands below with `bask-pg0308u05a` and any instance of `<SECONDARY_NODE>` with `bask-pg0308u06a`.
 
-## 11. Configure the primary node.
+### 11. Configure the primary node.
 
 ```shell
 $ cd llama
@@ -243,7 +243,7 @@ If you’ve deleted the virtual environment, you can create it again using the i
 
 Since we now have two nodes to worry about, we’ll need to configure the second node as well.
 
-## 12. Log in to the secondary node.
+### 12. Log in to the secondary node.
 
 If you’re using gnu screen or tmux you can switch to a new shell.
 If you’ve opened two terminals, move to the other terminal.
@@ -253,7 +253,7 @@ Either way, make sure you leave the shell on the primary node running.
 $ ssh <SECONDARY_NODE>
 ```
 
-## 13. Configure the secondary node.
+### 13. Configure the secondary node.
 
 This is the same as for the primary node, but we have to do it on both.
 
@@ -266,7 +266,7 @@ $ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
 $ . ./venv/bin/activate
 ```
 
-## 14. Execute the example script on the primary node:
+### 14. Execute the example script on the primary node:
 
 Move back to the shell on the primary node.
 You can now start the example script.
@@ -290,7 +290,7 @@ This command runs the script using `torchrun`, telling it to use two nodes and f
 Since this is only running on a single node it will only start up four of the eight processes.
 The script will wait until the other four processes have started (which we’ll do in the next step) before continuing.
 
-## 15. Execute the example script on the secondary node:
+### 15. Execute the example script on the secondary node:
 
 Now move to the terminal on the secondary node and run this similar &mdash; but not *quite* identical &mdash; command.
 
@@ -308,7 +308,7 @@ $ python -m torch.distributed.run \
     --max_batch_size 6
 ```
 
-## 16. Await the results
+### 16. Await the results
 
 Eventually the script will generate output using the model which is output to the console.
 You should get very similar output on both nodes.
@@ -331,7 +331,7 @@ Romance in the air
 [...]
 ```
 
-## 17. Tidy up
+### 17. Tidy up
 
 Make sure you log out of both nodes once you’re done by running the following commands on both nodes.
 This will release the resources and make them available for use by others.

--- a/Baskerville/llama2-inference-srun.md
+++ b/Baskerville/llama2-inference-srun.md
@@ -1,0 +1,344 @@
+# Llama 2 inference on Baskerville using `srun`
+
+Before you can make use of them you’ll need to download the models.
+See [llama-download.md](llama-download.md) for how to go about doing this on Baskerville.
+
+# Llama 2 7B inference, single node, single GPU
+
+The 7B parameter Llama 2 model will run with a single process on a single node with a single GPU.
+The checkpoint provided for use with the example will, in fact, only work with a single process.
+
+We found at least 16 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured using `srun` for things to work.
+
+## 1. Log in to a single node with a single GPU and a suitable configuration:
+
+You’ll need to replace `<PROJECT_ID>` with the name of your project.
+
+```shell
+$ srun --qos turing \
+    --account <PROJECT_ID> \
+    --time 0:30:0 \
+    --nodes 1 \
+    --gpus 1 \
+    --mem 16384 \
+    --pty bash
+```
+
+## 2. Set up the environment on the node:
+
+Note that the very first command here moves in to the `llama` directory, which is the directory containing the `example_text_completion.py` file.
+We have to be inside this directory for things to work.
+
+```shell
+$ cd llama
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ python -m venv venv
+$ . ./venv/bin/activate
+$ pip install pip --upgrade
+$ pip install -e .
+$ pip install -r requirements.txt
+```
+
+## 3. Run the example script that performs a bunch of inference steps:
+
+```shell
+$ python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 1 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-7b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+You should see some output that looks something like this:
+
+```text
+[...]
+Loaded in 20.01 seconds
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+Love locks on bridge embrace
+River Seine's gentle flow
+
+==================================
+[...]
+```
+
+One things to note is that in the Llama docs it [recommends](https://github.com/meta-llama/llama?tab=readme-ov-file#quick-start) to use `torchrun` to execute the script.
+When `torchrun` is used directly in this way it doesn’t support Python virtual environments because it defaults to the system-installed Python.
+To circumvent this we’ve switched `torchrun` out for `python -m torch.distributed.run` instead.
+
+## 4. Tidy up
+
+Once you’re done don’t forget to log out of the node so that it can be released for access by someone else.
+If you forget to do this the node will automatically close your session once the full 30 minutes you requested are up.
+
+```
+$ deactivate
+$ exit
+```
+
+# Llama 2 13B inference, single node, two GPUs
+
+The 13B parameter Llama 2 model will run with two processes on a single node with two GPUs.
+This arrangement is a requirement for the checkpoint to work.
+
+We found at least 32 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured using `srun` for things to work.
+
+## 5. Log in to a single node with a single GPU and a suitable configuration:
+
+You’ll need to replace `<PROJECT_ID>` with the name of your project.
+
+```shell
+$ srun --qos turing \
+    --account <PROJECT_ID> \
+    --time 0:30:0 \
+    --nodes 1 \
+    --gpus 2 \
+    --mem 32768 \
+    --pty bash
+```
+
+## 6. Set up the environment on the node:
+
+We assume you’re already in the `llama` directory as in step 2 above.
+If not you should use `cd` to move there first.
+
+```shell
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ . ./venv/bin/activate
+```
+
+We’re also assuming here that the virtual environment was already created in step 2 above, so we just activate it.
+If you’ve not already done this then you’ll need to run the commands there to create it as well.
+
+## 7. Run the example script that performs a bunch of inference steps:
+
+```shell
+$ python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 2 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-13b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+You should see some output that looks something like this:
+
+```text
+[...]
+Loaded in 27.98 seconds
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+River Seine's gentle flow
+Art and love in air
+
+==================================
+[...]
+```
+
+## 8. Tidy up
+
+Once you’re done don’t forget to log out of the node so that it can be released for access by someone else.
+If you forget to do this the node will automatically close your session once the full 30 minutes you requested are up.
+
+```
+$ deactivate
+$ exit
+```
+
+# Llama 2 70B inference, two nodes, eight GPUs
+
+The 70B parameter LLama 2 model requires considerably more resources to execute compared to the smaller Llama 2 models.
+The checkpoint provided for the example script requires eight processes and eight GPUs.
+On Baskerville this means we’ll need to use two nodes, each with four GPUs.
+
+This complicates matters when using `srun` because we’ll need to manually run `tourch.distributed.run` on each node.
+We can do this, it just means we need to log in to two nodes simultaneously.
+Using `screen` or `tmux` will make your life a lot easier when doing this.
+If you’re not comfortable with either of these, as an alternative you can open two terminals and log in to Baskerville twice.
+You’ll end up with a similar experience.
+
+## 9. Provision two nodes:
+
+Here you’ll again need to replace `<PROJECT_ID>` with the name of your project.
+
+```shell
+srun --qos turing \
+    --account <PROJECT_ID> \
+    --time 0:30:0 \
+    --nodes 2 \
+    --gpus 8 \
+    --mem 131072 \
+    --pty bash
+```
+
+In the above command we’re provisioning two nodes, eight GPUs and 32 GiB of RAM.
+We’ll need all of this computing power to run the model (the checkpoint requires eight processes).
+The `srun` command above not only provisions the node, it also logs you in to one of them.
+
+## 10. Find the names of the nodes.
+
+```shell
+$ squeue --me --format="%N" --noheader
+```
+
+This should output the names of two nodes separated by a comma.
+You’ll need to pick one of them to be the primary node (often referred to as the Master Node) and the other to be the secondary node.
+It doesn’t matter which is which.
+
+In future steps we’ll use `<PRIMARY_NODE>` to refer to one node and `<SECONDARY_NODE>` to refer to the other node.
+
+For example, I get the following output:
+
+```shell
+bask-pg0308u05a,bask-pg0308u06a
+```
+
+So I’d replace any instance of `<PRIMARY_NODE>` in the commands below with `bask-pg0308u05a` and any instance of `<SECONDARY_NODE>` with `bask-pg0308u06a`.
+
+## 11. Configure the primary node.
+
+```shell
+$ cd llama
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ . ./venv/bin/activate
+```
+
+Note that we’re not creating or configuring the virtual environment here because we assume you already did that in step 2.
+If you’ve deleted the virtual environment, you can create it again using the instructions provided there.
+
+Since we now have two nodes to worry about, we’ll need to configure the second node as well.
+
+## 12. Log in to the secondary node.
+
+If you’re using gnu screen or tmux you can switch to a new shell.
+If you’ve opened two terminals, move to the other terminal.
+Either way, make sure you leave the shell on the primary node running.
+
+```shell
+$ ssh <SECONDARY_NODE>
+```
+
+## 13. Configure the secondary node.
+
+This is the same as for the primary node, but we have to do it on both.
+
+```shell
+$ cd llama
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ . ./venv/bin/activate
+```
+
+## 14. Execute the example script on the primary node:
+
+Move back to the shell on the primary node.
+You can now start the example script.
+Don’t forget to replace `<PRIMARY_NODE>` in the command below with the name of the node.
+
+```shell
+$ python -m torch.distributed.run \
+    --nnodes 2 \
+    --nproc_per_node 4 \
+    --node_rank 0 \
+    --master_addr <PRIMARY_NODE> \
+    --master_port 6224 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-70b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+This command runs the script using `torchrun`, telling it to use two nodes and four processes per node (a total of eight processes, which is what we require).
+Since this is only running on a single node it will only start up four of the eight processes.
+The script will wait until the other four processes have started (which we’ll do in the next step) before continuing.
+
+## 15. Execute the example script on the secondary node:
+
+Now move to the terminal on the secondary node and run this similar &mdash; but not *quite* identical &mdash; command.
+
+```shell
+$ python -m torch.distributed.run \
+    --nnodes 2 \
+    --nproc_per_node 4 \
+    --node_rank 1 \
+    --master_addr <PRIMARY_NODE> \
+    --master_port 6224 \
+    example_chat_completion.py \
+    --ckpt_dir llama-2-70b-chat/ \
+    --tokenizer_path tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+## 16. Await the results
+
+Eventually the script will generate output using the model which is output to the console.
+You should get very similar output on both nodes.
+
+```text
+[...]
+Loaded in 55.34 seconds
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant:  Eiffel Tower high
+Art museums and fashion streets
+Romance in the air
+
+==================================
+[...]
+```
+
+## 17. Tidy up
+
+Make sure you log out of both nodes once you’re done by running the following commands on both nodes.
+This will release the resources and make them available for use by others.
+
+```
+$ deactivate
+$ exit
+```
+
+

--- a/Baskerville/llama3-inference-sbatch.md
+++ b/Baskerville/llama3-inference-sbatch.md
@@ -1,0 +1,296 @@
+# Llama 3 inference on Baskerville using `sbatch`
+
+Before you can make use of them you’ll need to download the models.
+See [llama-download.md](llama-download.md) for how to go about doing this on Baskerville.
+
+## Llama 3 8B inference, single node, single GPU
+
+The 8B parameter Llama 3 model will run with a single process on a single node with a single GPU.
+The checkpoint provided for use with the example will, in fact, only work with a single process.
+
+We found at least 32 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured through `sbatch` header for things to work.
+
+## 1. Get the full path of your llama3 directory.
+
+You should already have the llama3 git repository cloned to Baskerville.
+You’ll need the full path of where you cloned it to for the script.
+You can find this by moving into the directory and then running the `pwd` (print working directory) command:
+
+```shell
+$ cd llama3
+$ pwd
+```
+
+## 2. Create the batch script.
+
+Using your favourite text editor, create a batch file with the contents below.
+
+In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA3_PATH>` with the full path of your cloned llama3 repository from Step 1.
+
+Make sure you call the script `batch-llama3-8b-inf.sh`.
+Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
+
+```shell
+#!/bin/bash
+#SBATCH --qos turing
+#SBATCH --account <PROJECT_ID>
+#SBATCH --time 0:30:0
+#SBATCH --nodes 1
+#SBATCH --gpus 1
+#SBATCH --mem 32768
+#SBATCH --job-name llama3-8b-inf
+
+# Execute using:
+# sbatch -o stdout-%A_%a.out ./batch-llama3-8b-inf.sh
+
+module purge
+module load baskerville
+module load bask-apps/live
+module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+
+VENV_PATH="./venv"
+
+pushd <LLAMA3_PATH>
+
+if [ -d "$VENV_PATH" ]; then
+    echo "Virtual environment exists, activating"
+    . "${VENV_PATH}"/bin/activate
+else
+    echo "Creating and activating virtual environment"
+    python3 -m venv "${VENV_PATH}"
+    . "${VENV_PATH}"/bin/activate
+    echo "Installing requirements"
+    pip install pip --upgrade
+    pip install -e .
+    pip install -r requirements.txt
+fi
+
+export OMP_NUM_THREADS=1
+
+echo
+echo "######################################"
+echo "Starting"
+echo "######################################"
+echo
+
+python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 1 \
+    example_chat_completion.py \
+    --ckpt_dir Meta-Llama-3-8B-Instruct/ \
+    --tokenizer_path Meta-Llama-3-8B-Instruct/tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+
+echo
+echo "######################################"
+echo "Done"
+echo "######################################"
+echo
+
+echo "Deactivating virtual environment"
+deactivate
+popd
+```
+
+You’ll either need to create this batch file directly on Baskerville, or transfer it to Baskerville.
+It doesn’t matter where you store it on Baskerville.
+
+## 3. Schedule the job file to run.
+
+```shell
+$ sbatch -o stdout-%A_%a.out ./batch-llama3-8b-inf.sh
+```
+
+## 4. Check the status of your job.
+
+Use the following command to check the status of your job.
+Once it’s completed it will disappear from the queue.
+
+```shell
+$ squeue --me
+```
+
+This is a small job so it shouldn’t take too long to schedule and run (it took less than five minutes for me, but will depend on how busy Baskerville is when you run it).
+
+## 5. View the results in realtime.
+
+The console output from the job will be stored in a file with a name of the form `stdout-%A_%a.out` where the `%A` and `%a` are replaced by the job ID and array index respectively.
+For example, for me the file was called `stdout-763144_4294967294.out`.
+
+If you want to follow the progress of the execution in real time &mdash; while it’s running that is &mdash; you can execute the following command to follow the output.
+If you have multiple output files you may need to specify the filename explicitly, rather than relying on the `*` wildcard.
+
+```shell
+tail -f stdout-*.out
+```
+
+## 6. View the results after completion.
+
+Once the job has completed you can view open the `stdout-%A_%a.out` file to see the results.
+It should contain something like this:
+
+```text
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant: Eiffel's iron kiss
+River Seine's gentle whispers
+Art in every stone
+
+==================================
+[...]
+```
+
+## Llama 3 70B inference, two nodes, eight GPUs
+
+The 70B parameter LLama 3 model requires considerably more resources to execute compared to the 8B parameter model.
+The checkpoint provided for the example script requires eight processes and eight GPUs.
+On Baskerville this means we’ll need to use two nodes, each with four GPUs.
+
+Thankfully it’s considerably easier to do this using `sbatch` compared to `srun`.
+Let’s do it now.
+
+## 7. Create the batch script.
+
+Using your favourite text editor, create a batch file with the contents below.
+
+In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA3_PATH>` with the full path of your cloned llama3 repository from Step 1.
+
+Make sure you call the script `batch-llama3-70b-inf.sh`.
+Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
+
+```shell
+#!/bin/bash
+#SBATCH --qos turing
+#SBATCH --account vjgo8416-ml-workload
+#SBATCH --time 0:30:0
+#SBATCH --nodes 2
+#SBATCH --gpus-per-node 4
+#SBATCH --ntasks-per-node 1
+#SBATCH --mem 131072
+#SBATCH --job-name llama3-70b-inf
+
+# Execute using:
+# sbatch -o stdout-%A_%a.out ./batch-llama3-70b-inf.sh
+
+module purge
+module load baskerville
+module load bask-apps/live
+module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+
+VENV_PATH="./venv"
+
+pushd /bask/projects/v/vjgo8416-ml-workload/llama/llama3
+
+if [ -d "$VENV_PATH" ]; then
+    echo "Virtual environment exists, activating"
+    . "${VENV_PATH}"/bin/activate
+else
+    echo "Creating and activating virtual environment"
+    python3 -m venv "${VENV_PATH}"
+    . "${VENV_PATH}"/bin/activate
+    echo "Installing requirements"
+    pip install pip --upgrade
+    pip install -e .
+    pip install -r requirements.txt
+fi
+
+export PRIMARY_PORT=12340
+export PRIMARY_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export OMP_NUM_THREADS=1
+
+echo
+echo "######################################"
+echo "Starting"
+echo "######################################"
+echo
+
+srun bash -c \
+    ‘python -m torch.distributed.run \
+    --nnodes ${SLURM_NNODES} \
+    --nproc_per_node ${SLURM_GPUS_PER_NODE} \
+    --master_addr ${PRIMARY_ADDR} \
+    --master_port ${PRIMARY_PORT} \
+    --node_rank ${SLURM_NODEID} \
+    example_chat_completion.py \
+    --ckpt_dir Meta-Llama-3-70B-Instruct/ \
+    --tokenizer_path Meta-Llama-3-70B-Instruct/tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6’
+
+echo
+echo "######################################"
+echo "Done"
+echo "######################################"
+echo
+
+echo "Deactivating virtual environment"
+deactivate
+popd
+```
+
+Once again, you’ll need to either create this script directly on Baskerville or copy it over.
+
+There are a couple of important things to note about this script.
+First, because we’re running across multiple nodes using `torchrun` we have to pass our training command through `srun`.
+This will ensure multiple processes get spawned, one on each node.
+The syntax for `srun` is to execute the command passed as a parameter on each of the nodes.
+
+We also need to pass various parameters to our Python script, some of which are taken from environment variables.
+The second point to note is about these parameters.
+Most of the parameters can be set to the same value for each process, but there’s one exception, which is the value passed as the node rank: `--node_rank ${SLURM_NODEID}`.
+This needs to take a different value on each node so that the nodes can communicate with each other successfully.
+
+The `SLURM_NODEID` environment variable will automatically be set to a different value on each node by `srun`.
+However this means we need to be careful about how we pass the command to `srun`.
+If we passed the `python` command directly, this `SLURM_NODEID` will be resolved on the spawning node and its value will then end up the same on each node.
+
+Consequently we have to create a string out of our entire command and use `bash` to run the command.
+That way `srun` will spawn the `bash` shell on each node, which will then interpret the `python` command on that node.
+The `SLURM_NODEID` environment variable won’t then get resolved until the command is run on the node, which is what we need.
+
+## 8. Schedule the job file to run.
+
+```shell
+$ sbatch -o stdout-%A_%a.out ./batch-llama3-70b-inf.sh
+```
+
+## 9. Follow the results.
+
+As before you can check the status of your job using the following:
+
+```shell
+squeue --me
+```
+
+You can also check the output of the `stdout-%A_%a.out` file to see the results, either by following it during execution or opening the file afterwards.
+
+## 10. View the results after completion.
+
+Once the job has completed you can view open the `stdout-%A_%a.out` file to see the results. It should contain something like this:
+
+```text
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant: Eiffel's iron lace
+River Seine's gentle whisper
+Montmartre's charm waits
+
+==================================
+[...]
+```
+

--- a/Baskerville/llama3-inference-sbatch.md
+++ b/Baskerville/llama3-inference-sbatch.md
@@ -30,6 +30,8 @@ Using your favourite text editor, create a batch file with the contents below.
 
 In this script you’ll need to replace `<PROJECT_ID>` with the name of your project and `<LLAMA3_PATH>` with the full path of your cloned llama3 repository from Step 1.
 
+If it doesn't already exist, a virtual environment will be created and configured automatically in a directory called `venv` immediately inside the directory you set `<LLAMA3_PATH>` to.
+
 Make sure you call the script `batch-llama3-8b-inf.sh`.
 Technically you can give it any name, but I’ve assumed it’s called this in the steps that follow.
 

--- a/Baskerville/llama3-inference-srun.md
+++ b/Baskerville/llama3-inference-srun.md
@@ -1,0 +1,254 @@
+# Llama 3 inference on Baskerville using `srun`
+
+Before you can make use of them you’ll need to download the models.
+See [llama-download.md](llama-download.md) for how to go about doing this on Baskerville.
+
+# Llama 3 8B inference, single node, single GPU
+
+The 8B parameter Llama 3 model will run with a single process on a single node with a single GPU.
+The checkpoint provided for use with the example will, in fact, only work with a single process.
+
+We found at least 32 GiB of RAM was needed to run the model.
+With too little RAM the process will be sent a SIGKILL termination signal, the process will end with an exit code of -9 and an OOM report will be generated.
+
+The RAM, node, GPU and process quantities must be explicitly configured using `srun` for things to work.
+
+## 1. Log in to a single node with a single GPU and a suitable configuration:
+
+You’ll need to replace `<PROJECT_ID>` with the name of your project.
+
+```shell
+$ srun --qos turing \
+    --account <PROJECT_ID> \
+    --time 0:30:0 \
+    --nodes 1 \
+    --gpus 1 \
+    --mem 32768 \
+    --pty bash
+```
+
+## 2. Set up the environment on the node:
+
+```shell
+$ cd llama3
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ python -m venv venv
+$ . ./venv/bin/activate
+$ pip install pip --upgrade
+$ pip install -e .
+$ pip install -r requirements.txt
+```
+
+## 3. Run the example script that performs a bunch of inference steps:
+
+```shell
+$ python -m torch.distributed.run \
+    --standalone \
+    --nnodes 1 \
+    --nproc_per_node 1 \
+    example_chat_completion.py \
+    --ckpt_dir Meta-Llama-3-8B-Instruct/ \
+    --tokenizer_path Meta-Llama-3-8B-Instruct/tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+You should see some output that looks something like this:
+
+```text
+[...]
+Loaded in 10.39 seconds
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant: Eiffel's iron kiss
+River Seine's gentle whispers
+Art in every stone
+
+==================================
+```
+
+One things to note is that in the Llama 3 docs it [recommends](https://github.com/meta-llama/llama3?tab=readme-ov-file#quick-start) to use `torchrun` to execute the script.
+When `torchrun` is used directly in thisß way it doesn’t support Python virtual environments because it defaults to the system-installed Python.
+To circumvent this we’ve switched `torchrun` out for `python -m torch.distributed.run` instead.
+
+## 4. Tidy up
+
+Once you’re done don’t forget to log out of the node so that it can be released for access by someone else.
+If you forget to do this the node will automatically close your session once the full 30 minutes you requested are up.
+
+```
+$ deactivate
+$ exit
+```
+
+# Llama 3 70B inference, two nodes, eight GPUs
+
+The 70B parameter LLama 3 model requires considerably more resources to execute compared to the 8B parameter model.
+The checkpoint provided for the example script requires eight processes and eight GPUs.
+On Baskerville this means we’ll need to use two nodes, each with four GPUs.
+
+This complicates matters when using `srun` because we’ll need to manually run `tourch.distributed.run` on each node.
+We can do this, it just means we need to log in to two nodes simultaneously.
+Using `screen` or `tmux` will make your life a lot easier when doing this.
+If you’re not comfortable with either of these, as an alternative you can open two terminals and log in to Baskerville twice.
+You’ll end up with a similar experience.
+
+## 5. Provision two nodes:
+
+Here you’ll again need to replace `<PROJECT_ID>` with the name of your project.
+
+```shell
+srun --qos turing \
+    --account <PROJECT_ID> \
+    --time 0:30:0 \
+    --nodes 2 \
+    --gpus 8 \
+    --mem 131072 \
+    --pty bash
+```
+
+In the above command we’re provisioning two nodes, eight GPUs and 128 GiB of RAM.
+We’ll need all of this computing power to run the model (the checkpoint requires eight processes).
+The `srun` command above not only provisions the node, it also logs you in to one of them.
+
+## 6. Find the names of the nodes.
+
+```shell
+$ squeue --me --format="%N" --noheader
+```
+
+This should output the names of two nodes separated by a comma.
+You’ll need to pick one of them to be the primary node (often referred to as the Master Node) and the other to be the secondary node.
+It doesn’t matter which is which.
+
+In future steps we’ll use `<PRIMARY_NODE>` to refer to one node and `<SECONDARY_NODE>` to refer to the other node.
+
+For example, I get the following output:
+
+```shell
+bask-pg0308u05a,bask-pg0308u06a
+```
+
+So I’d replace any instance of `<PRIMARY_NODE>` in the commands below with `bask-pg0308u05a` and any instance of `<SECONDARY_NODE>` with `bask-pg0308u06a`.
+
+## 7. Configure the primary node.
+
+```shell
+$ cd llama3
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ . ./venv/bin/activate
+```
+
+Note that we’re not creating or configuring the virtual environment here because we assume you already did that in step 2.
+If you’ve deleted the virtual environment, you can create it again using the instructions provided there.
+
+Since we now have two nodes to worry about, we’ll need to configure the second node as well.
+
+## 8. Log in to the secondary node.
+
+If you’re using gnu screen or tmux you can switch to a new shell.
+If you’ve opened two terminals, move to the other terminal.
+Either way, make sure you leave the shell on the primary node running.
+
+```shell
+$ ssh <SECONDARY_NODE>
+```
+
+## 9. Configure the secondary node.
+
+This is the same as for the primary node, but we have to do it on both.
+
+```shell
+$ cd llama3
+$ module purge
+$ module load baskerville
+$ module load bask-apps/live
+$ module load PyTorch/2.1.2-foss-2022b-CUDA-11.8.0
+$ . ./venv/bin/activate
+```
+
+## 10. Execute the example script on the primary node:
+
+Move back to the shell on the primary node.
+You can now start the example script.
+Don’t forget to replace `<PRIMARY_NODE>` in the command below with the name of the node.
+
+```shell
+$ python -m torch.distributed.run \
+    --nnodes 2 \
+    --nproc_per_node 4 \
+    --node_rank 0 \
+    --master_addr <PRIMARY_NODE> \
+    --master_port 6224 \
+    example_chat_completion.py \
+    --ckpt_dir Meta-Llama-3-70B-Instruct/ \
+    --tokenizer_path Meta-Llama-3-70B-Instruct/tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+This command runs the script using `torchrun`, telling it to use two nodes and four processes per node (a total of eight processes, which is what we require).
+Since this is only running on a single node it will only start up four of the eight processes.
+The script will wait until the other four processes have started (which we’ll do in the next step) before continuing.
+
+## 11. Execute the example script on the secondary node:
+
+Now move to the terminal on the secondary node and run this similar &mdash; but not *quite* identical &mdash; command.
+
+```shell
+$ python -m torch.distributed.run \
+    --nnodes 2 \
+    --nproc_per_node 4 \
+    --node_rank 1 \
+    --master_addr <PRIMARY_NODE> \
+    --master_port=6224 \
+    example_chat_completion.py \
+    --ckpt_dir Meta-Llama-3-70B-Instruct/ \
+    --tokenizer_path Meta-Llama-3-70B-Instruct/tokenizer.model \
+    --max_seq_len 512 \
+    --max_batch_size 6
+```
+
+## 12. Await the results
+
+Eventually the script will generate output using the model which is output to the console.
+You should get very similar output on both nodes.
+
+```text
+[...]
+Loaded in 30.96 seconds
+[...]
+==================================
+
+System: Always answer with Haiku
+
+User: I am going to Paris, what should I see?
+
+> Assistant: Eiffel's iron lace
+River Seine's gentle whisper
+Montmartre's charm waits
+
+==================================
+```
+
+## 13. Tidy up
+
+Make sure you log out of both nodes once you’re done by running the following commands on both nodes.
+This will release the resources and make them available for use by others.
+
+```
+$ deactivate
+$ exit
+```
+

--- a/Baskerville/llama3-inference-srun.md
+++ b/Baskerville/llama3-inference-srun.md
@@ -76,7 +76,7 @@ Art in every stone
 ```
 
 One things to note is that in the Llama 3 docs it [recommends](https://github.com/meta-llama/llama3?tab=readme-ov-file#quick-start) to use `torchrun` to execute the script.
-When `torchrun` is used directly in thisß way it doesn’t support Python virtual environments because it defaults to the system-installed Python.
+When `torchrun` is used directly in this way it doesn’t support Python virtual environments because it defaults to the system-installed Python.
 To circumvent this we’ve switched `torchrun` out for `python -m torch.distributed.run` instead.
 
 ## 4. Tidy up


### PR DESCRIPTION
Adds walkthroughs for running various Llama models for inference using Baskerville.

Covers:
1. Llama 2 7B using srun or sbatch on a single node with one GPU.
2. Llama 2 13B using srun or sbatch on a single node with two GPUs.
3. Llama 2 70B using srun or sbatch on two nodes with eight GPUs.
4. Llama 3 8B using srun or sbatch on a single node with one GPU.
5. Llama 3 70B using srun or sbatch on two nodes with eight GPUs.